### PR TITLE
Use NonZeroUsize for the capacity parameter in the constructor

### DIFF
--- a/benches/concurrency.rs
+++ b/benches/concurrency.rs
@@ -1,6 +1,7 @@
 use criterion::*;
 use rayon::{current_num_threads, scope};
 use ring_channel::*;
+use std::num::NonZeroUsize;
 
 fn concurrency(c: &mut Criterion) {
     let cardinality = 10000;
@@ -10,7 +11,7 @@ fn concurrency(c: &mut Criterion) {
         "concurrency",
         Benchmark::new(cardinality.to_string(), move |b| {
             b.iter_batched_ref(
-                || ring_channel::<usize>(1),
+                || ring_channel::<usize>(NonZeroUsize::new(1).unwrap()),
                 |(tx, rx)| {
                     scope(|s| {
                         for _ in 0..concurrency / 2 {

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -1,6 +1,7 @@
 use criterion::*;
 use rayon::{current_num_threads, scope};
 use ring_channel::*;
+use std::num::NonZeroUsize;
 use std::thread;
 
 fn throughput(m: usize, n: usize, messages: usize) -> ParameterizedBenchmark<usize> {
@@ -9,7 +10,7 @@ fn throughput(m: usize, n: usize, messages: usize) -> ParameterizedBenchmark<usi
         move |b, &capacity| {
             b.iter_batched(
                 || {
-                    let (tx, rx) = ring_channel(capacity);
+                    let (tx, rx) = ring_channel(NonZeroUsize::new(capacity).unwrap());
                     (vec![tx; m], vec![rx; n])
                 },
                 |(txs, rxs)| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ pub use error::*;
 pub use receiver::*;
 pub use sender::*;
 
+use std::num::NonZeroUsize;
+
 /// Opens a multi-producer multi-consumer channel backed by a ring buffer.
 ///
 /// The associated ring buffer can contain up to `capacity` pending messages.
@@ -24,13 +26,14 @@ pub use sender::*;
 ///
 /// ```rust,no_run
 /// use ring_channel::*;
+/// use std::num::NonZeroUsize;
 /// use std::thread;
 /// use std::time::{Duration, Instant};
 ///
 /// fn main() {
 ///     // Open a channel to transmit the time elapsed since the beginning of the countdown.
 ///     // We only need a buffer of size 1, since we're only interested in the current value.
-///     let (tx, rx) = ring_channel(1);
+///     let (tx, rx) = ring_channel(NonZeroUsize::new(1).unwrap());
 ///
 ///     thread::spawn(move || {
 ///         let countdown = Instant::now() + Duration::from_secs(10);
@@ -67,19 +70,7 @@ pub use sender::*;
 ///     println!("\r00.0000 - Solid rocket booster ignition and liftoff!")
 /// }
 /// ```
-pub fn ring_channel<T>(capacity: usize) -> (RingSender<T>, RingReceiver<T>) {
-    assert!(capacity > 0, "capacity must be greater than zero");
-    let channel::RingChannel(left, right) = channel::RingChannel::new(capacity);
+pub fn ring_channel<T>(capacity: NonZeroUsize) -> (RingSender<T>, RingReceiver<T>) {
+    let channel::RingChannel(left, right) = channel::RingChannel::new(capacity.get());
     (RingSender(left), RingReceiver(right))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    #[should_panic]
-    fn ring_channel_panics_on_zero_capacity() {
-        ring_channel::<()>(0);
-    }
 }


### PR DESCRIPTION
Suggestion by [Zack_Pierce](https://www.reddit.com/user/Zack_Pierce) on [reddit](https://www.reddit.com/r/rust/comments/bdkmw1/announcing_ringchannel_a_bounded_mpmc_channel/ekzlcai/)

> If you don't mind an unsolicited minor suggestion, have you considered using NonZeroUsize for the capacity parameter in the constructor(s)? It would clarify the intent regarding the non-zero-size requirement and turn a runtime panic into a compile-time guarantee.