### PR TITLE
Release v0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ futures-preview = { version = "0.3.0-alpha.14", optional = true }
 
 [dev-dependencies]
 criterion = "0.2.10"
-proptest = "0.9.2"
+proptest = "0.9.3"
 rayon = "1.0.3"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ring-channel"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 authors = ["Bruno Dutra <brunocodutra@gmail.com>"]
 description = "Never blocking, bounded MPMC channel abstraction on top of a ring buffer"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ RingChannel is available on [crates.io][crate.home], simply add it as a dependen
 
 ```
 [dependencies]
-ring-channel = "0.2"
+ring-channel = "0.3"
 ```
 
 The full API documentation is available on [docs.rs][docs.home]


### PR DESCRIPTION
With experimental support for the [`Sink`](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.14/futures/sink/trait.Sink.html) and [`Stream`](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures/stream/trait.Stream.html) traits as defined by [futures-rs v0.3](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.14/futures/).

Addresses #13