### PR TITLE
update to futures 0.3.1(fix issue #37)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ all-features = true
 
 [features]
 default = ["futures_api"]
-futures_api = ["futures-preview"]
+futures_api = ["futures"]
 
 [badges]
 codecov = { repository = "brunocodutra/ring-channel" }
@@ -24,7 +24,7 @@ codecov = { repository = "brunocodutra/ring-channel" }
 crossbeam-queue = "0.1.2"
 crossbeam-utils = "0.6.6"
 derivative = "1.0.3"
-futures-preview = { version = "0.3.0-alpha.19", optional = true }
+futures = { version = "0.3.1", optional = true }
 spin = "0.5.2"
 smallvec = "0.6.10"
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -485,7 +485,8 @@ mod tests {
             let (mut tx, mut rx) = ring_channel(NonZeroUsize::new(cap).unwrap());
             let overwritten = msgs.len() - min(msgs.len(), cap);
 
-            assert_eq!(block_on(tx.send_all(&mut msgs.clone())), Ok(()));
+            let mut st = stream::iter(msgs.clone()).map(|msg| Ok(msg));
+            assert_eq!(block_on(tx.send_all(&mut st)), Ok(()));
 
             drop(tx); // hang-up
 
@@ -561,7 +562,7 @@ mod tests {
                     });
                 }
 
-                let mut msgs = stream::iter(vec![42; n]);
+                let mut msgs = stream::iter(vec![42; n]).map(|msg| Ok(msg));
                 s.spawn(move |_| assert_eq!(block_on(tx.send_all(&mut msgs)), Ok(())));
             });
         }
@@ -615,7 +616,7 @@ mod tests {
                     });
                 }
 
-                let mut msgs = stream::iter(vec![42; n]);
+                let mut msgs = stream::iter(vec![42; n]).map(|msg| Ok(msg));
                 s.spawn(move |_| assert_eq!(block_on(tx.send_all(&mut msgs)), Ok(())));
             });
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@
 //!
 //!     thread::spawn(move || {
 //!         // Send the stream of characters through the Sink.
-//!         block_on(tx.send_all(&mut stream::iter(message))).unwrap();
+//!         block_on(tx.send_all(&mut stream::iter(message).map(|msg| Ok(msg)))).unwrap();
 //!     });
 //!
 //!     // Receive the stream of characters through the outbound endpoint.


### PR DESCRIPTION
This PR relates to #37. It updates to `futures-preview` to `futures` 0.3.1 and fixes incompatibility changes.