### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ crossbeam-utils = { version = "0.8.7", default-features = false }
 derivative = { version = "2.2.0", default-features = false, features = ["use_core"] }
 futures = { version = "0.3.21", default-features = false, features = ["executor"], optional = true }
 slotmap = { version = "1.0.6", optional = true, default-features = false }
-spin = { version = "0.9.2", default-features = false, features = ["rwlock"], optional = true }
+spin = { version = "0.9.8", default-features = false, features = ["rwlock"], optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", default-features = false, features = ["async_tokio", "rayon"] }


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)